### PR TITLE
Improve admin notice for when Debug Bar is not active

### DIFF
--- a/debug-bar-taxonomies.php
+++ b/debug-bar-taxonomies.php
@@ -43,7 +43,7 @@ if ( ! function_exists( 'dbtax_has_parent_plugin' ) ) {
 		$file = plugin_basename( __FILE__ );
 
 		if ( is_admin() && ( ! class_exists( 'Debug_Bar' ) && current_user_can( 'activate_plugins' ) ) && is_plugin_active( $file ) ) {
-			add_action( 'admin_notices', create_function( null, 'echo \'<div class="error"><p>\' . sprintf( __( \'Activation failed: Debug Bar must be activated to use the <strong>Debug Bar Taxonomies</strong> Plugin. %sVisit your plugins page to activate.\', \'debug-bar-taxonomies\' ), \'<a href="\' . admin_url( \'plugins.php#debug-bar\' ) . \'">\' ) . \'</a></p></div>\';' ) );
+			add_action( 'admin_notices', create_function( null, 'echo \'<div class="error"><p>\' . sprintf( __( \'Activation failed: Debug Bar must be activated to use the <strong>Debug Bar Taxonomies</strong> Plugin. %sVisit your plugins page to install & activate.\', \'debug-bar-taxonomies\' ), \'<a href="\' . admin_url( \'plugin-install.php?tab=search&s=debug+bar\' ) . \'">\' ) . \'</a></p></div>\';' ) );
 
 			deactivate_plugins( $file, false, is_network_admin() );
 


### PR DESCRIPTION
Link to the plugin-install page instead which allows people to install *and* activate and doesn't presume they already have the Debug Bar installed, just not active.

Props musamamasood