### PR TITLE
README: Add "Requires PHP" header

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,6 +6,7 @@ Requires at least: 3.4
 Tested up to: 4.8
 Stable tag: 1.1
 Depends: Debug Bar
+Requires PHP: 5.2.4
 License: GPLv2
 
 Debug Bar Taxonomies adds a new panel to the Debug Bar with detailed information about registered taxonomies. Requires "Debug Bar" plugin.


### PR DESCRIPTION
This new header has been soft launched on August 25th 2017.

Refs:
* https://meta.trac.wordpress.org/ticket/2952
* https://meta.trac.wordpress.org/changeset/5841

https://wordpress.org/plugins/developers/readme-validator/