### PR TITLE
Travis: More stable solution for removing Xdebug when not needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
 
 before_install:
     # Speed up build time by disabling Xdebug when its not needed.
-    - if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then phpenv config-rm xdebug.ini; fi
+    - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
     # Set up temporary paths.
     - export PHPCS_DIR=/tmp/phpcs
     - export WPCS_DIR=/tmp/wpcs


### PR DESCRIPTION
Builds onto https://github.com/jrfnl/Debug-Bar-Taxonomies/pull/15/commits/8e8df8a56b52536a6fc2047305f1dbc4c5ad0889

As per https://twitter.com/kelunik/status/954242454676475904

When newer images of PHP versions become available, Xdebug isn't always installed.
Using this little titbit, the builds won't break because of it.